### PR TITLE
feat: improve curl error handling and add GitHub token authentication

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
       run: |
         VERSION="${{ inputs.version }}"
         if [ "$VERSION" = "latest" ]; then
-          VERSION=$(curl -s https://api.github.com/repos/hirosassa/ksnotify/releases/latest | jq -r .tag_name)
+          VERSION=$(curl -sf -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/hirosassa/ksnotify/releases/latest | jq -r .tag_name)
         fi
 
         # Detect OS and set appropriate filename
@@ -45,7 +45,7 @@ runs:
         DOWNLOAD_URL="https://github.com/hirosassa/ksnotify/releases/download/${VERSION}/${FILENAME}"
         echo "Downloading ksnotify from: $DOWNLOAD_URL"
 
-        curl -sL "$DOWNLOAD_URL" -o "/tmp/${FILENAME}"
+        curl -H "Authorization: Bearer ${{ github.token }}" -sfL "$DOWNLOAD_URL" -o "/tmp/${FILENAME}"
 
         # Extract based on file type
         if [[ "$FILENAME" == *.tar.gz ]]; then


### PR DESCRIPTION
## Summary
- curlコマンドに-fフラグを追加してHTTPエラー時に適切に失敗するように改善
- GitHub APIの呼び出しにトークン認証を追加してレート制限を回避
- バージョン取得とファイルダウンロードの信頼性を向上

## Changes
- API呼び出し時のcurlに`-f`オプションを追加（HTTPエラーで失敗）
- `${{ github.token }}`を使用してGitHub API認証を追加
- レート制限の回避とエラーハンドリングの改善

## Test plan
- [x] GitHub Actions上でテストを実行
- [x] 異なるOSでの動作確認
- [x] エラーケースの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)